### PR TITLE
make javascript use UTC timestamps when asking for new log messages

### DIFF
--- a/monlog/log/api.py
+++ b/monlog/log/api.py
@@ -45,12 +45,16 @@ class LogCollectionResource(ModelResource):
 
         if 'datetime__gte' in filters:
             filters['datetime__gte'] = filters['datetime__gte'].replace("T", " ")
+            filters['datetime__gte'] = filters['datetime__gte'].replace("Z", "")
         if 'datetime__lte' in filters:
             filters['datetime__lte'] = filters['datetime__lte'].replace("T", " ")
+            filters['datetime__lte'] = filters['datetime__lte'].replace("Z", "")
         if 'add_datetime__gte' in filters:
             filters['add_datetime__gte'] = filters['add_datetime__gte'].replace("T", " ")
+            filters['add_datetime__gte'] = filters['add_datetime__gte'].replace("Z", "")
         if 'add_datetime__lte' in filters:
             filters['add_datetime__lte'] = filters['add_datetime__lte'].replace("T", " ")
+            filters['add_datetime__lte'] = filters['add_datetime__lte'].replace("Z", "")
 
         orm = super(LogCollectionResource, self).build_filters(filters)
 

--- a/monlog/static/js/api.js
+++ b/monlog/static/js/api.js
@@ -9,12 +9,12 @@ var refreshTimeout = 5000;
 // https://developer.mozilla.org/en/Core_JavaScript_1.5_Reference:Global_Objects:Date#Example:_ISO_8601_formatted_dates
 function ISODateString(d){
   function pad(n){return n<10 ? '0'+n : n}
-  return d.getFullYear()+'-'
-      + pad(d.getMonth()+1)+'-'
-      + pad(d.getDate())+'T'
-      + pad(d.getHours())+':'
-      + pad(d.getMinutes())+':'
-      + pad(d.getSeconds())
+  return d.getUTCFullYear()+'-'
+      + pad(d.getUTCMonth()+1)+'-'
+      + pad(d.getUTCDate())+'T'
+      + pad(d.getUTCHours())+':'
+      + pad(d.getUTCMinutes())+':'
+      + pad(d.getUTCSeconds())+'Z'
 }
 
 var displayLogMessages = function(data) {
@@ -58,7 +58,6 @@ var requestLogMessages = function(update, was_refresh) {
     $.getJSON(url,
         function(data,textStatus,jqXHR) {
             if (update) {
-                console.log($('.content table tbody tr'));
                 displayLogMessages(data, true);
                 $("#loading_indicator").fadeOut(300);
             } else {


### PR DESCRIPTION
Fixes 'new log messages' notification that was broken since merge of UTC last time
